### PR TITLE
Pingback implementation on client and server

### DIFF
--- a/cache/server.js
+++ b/cache/server.js
@@ -71,6 +71,8 @@ class Server {
     this.routes_.push({regexp: /^\/.*\/.*/, handler: proxy.getHandler()});
     this.routes_.push({regexp: /^\/serveraccess/,
         handler: proxy.getServerAccessHandler()});
+    this.routes_.push({regexp: /^\/serverping/,
+        handler: proxy.getServerPingHandler()});
   }
 
   start() {

--- a/pub/app.js
+++ b/pub/app.js
@@ -112,7 +112,17 @@ app.get('/access', function(req, res) {
 /** ACCESS CORS */
 app.get('/access-client', function(req, res) {
   console.log('Client access verification');
-  var readerId = req.query.rid;
+  outputAccessData(req, res, /* isView */ false);
+});
+
+/** PINGBACK CORS */
+app.get('/ping', function(req, res) {
+  console.log('Pingback');
+  outputAccessData(req, res, /* isView */ true);
+});
+
+function outputAccessData(req, res, isView) {
+  var readerId = req.query['rid'];
   if (!readerId) {
     res.sendStatus(400);
     return;
@@ -131,8 +141,11 @@ app.get('/access-client', function(req, res) {
     clientAuth = {};
     CLIENT_ACCESS[readerId] = clientAuth;
   }
-  var views = (clientAuth.views || 0) + 1;
-  clientAuth.views = views;
+  var views = clientAuth.views || 0;
+  if (isView) {
+    views++;
+    clientAuth.views = views;
+  }
 
   res.json({
     'views': views,
@@ -140,7 +153,7 @@ app.get('/access-client', function(req, res) {
     'access': (views <= MAX_VIEWS),
     'validUntil': new Date().getTime() + 20000,  // Valid for 20 seconds
   });
-});
+}
 
 
 var server = app.listen(PORT, function() {

--- a/pub/archive/article-client.amp.html
+++ b/pub/archive/article-client.amp.html
@@ -7,11 +7,8 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <meta name="amp-access" content="type=client;
       rpc=http://localhost:8002/access-client;
+      ping=http://localhost:8002/ping;
       login=http://localhost:8002/login">
-  <!--
-  <link rel="amp-access-rpc" href="http://localhost:8002/access">
-  <link rel="amp-access-login" href="http://localhost:8002/login">
-  -->
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <style amp-custom>
     body {
@@ -255,7 +252,7 @@
 </head>
 <body>
 
-  <div class="access-alert" amp-access="views &lt;= maxViews">
+  <div class="access-alert" amp-access="isView and views &lt;= maxViews">
     <button close>[X]</button>
     <div>
       <template amp-access-template type="amp-mustache">

--- a/pub/archive/article-server.amp.html
+++ b/pub/archive/article-server.amp.html
@@ -7,11 +7,8 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <meta name="amp-access" content="type=server;
       rpc=http://localhost:8002/access-client;
+      ping=http://localhost:8002/ping;
       login=http://localhost:8002/login">
-  <!--
-  <link rel="amp-access-rpc" href="http://localhost:8002/access">
-  <link rel="amp-access-login" href="http://localhost:8002/login">
-  -->
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <style amp-custom>
     body {
@@ -255,7 +252,7 @@
 </head>
 <body>
 
-  <div class="access-alert" amp-access="views &lt;= maxViews">
+  <div class="access-alert" amp-access="isView and views &lt;= maxViews">
     <button close>[X]</button>
     <div>
       <template amp-access-template type="amp-mustache">


### PR DESCRIPTION
The entry point is "ClientAuth.prototype.viewed".

Pingback has nearly the same API and response as Access RPC - just slightly different semantics.

To avoid showing metered message before pingback is done, the expression is now `isView and ...`.

One thing is a bit odd - in the server-side case the pingback is proxied via cache to publisher to pick up additional sections that the publisher enables via pingback. In this case it's the "metering section". To avoid resending already delivered sections, the set of loaded sections is included in the "sessions" URL parameter. It looks somewhat MSS-y.
