### PR TITLE
Add amp-analytics proxy sample

### DIFF
--- a/controllers/amp-analytics/proxy.js
+++ b/controllers/amp-analytics/proxy.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+var express = require('express');
+var uuid = require('uuid');
+var router = express.Router();
+var GA_HOST = "https://www.google-analytics.com";
+var EXPIRES = 60 * 60 * 24 * 365; //1 year
+
+/**
+ * Adds the uid parameter to the google-analytics request 
+ * and redirects to google-analytics. 
+ * 
+ * More info on UserID for google-analytics here:
+ *   - https://support.google.com/analytics/answer/3123662
+ *   - https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#uid
+ *   
+ * Example: /collect?cid=1234
+ */
+router.post('/', function(req, res) {
+  // Enable CORS.
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Credentials', 'true');
+
+  // Check for the userId cookie.
+  var uid = req.cookies.userId;
+
+  if (!uid) {
+    // Create a new userId if one doesn't exist.
+    uid = uuid.v4();
+    console.log("Generated new userId: " + uid);  
+
+    // The desktop website should be modified to use the value of the
+    // userId cookie as the userId in GA.
+    res.cookie('userId', uid, { maxAge: EXPIRES, httpOnly: true });    
+  }  
+
+  console.log("Redirecting to Google Analytics with UID: " + uid);
+
+  // Replace the cid in the request with the one from our domain.
+  var location = GA_HOST + req.originalUrl + "&uid=" + uid;
+
+  // Redirect the request to google-analytics.
+  res.setHeader("Location", location);
+  res.sendStatus(302);
+});
+
+module.exports = router;

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -21,6 +21,8 @@ var router = require('express').Router();
 router.use('/amp-access', require('./amp-access'));
 router.use('/amp-user-notification', require('./amp-user-notification'));
 router.use('/amp-analytics', require('./amp-analytics'));
+router.use('/*/collect', require('./amp-analytics/proxy'));
+router.use('/collect', require('./amp-analytics/proxy'));
 
 router.get('/', function(req, res) {
   res.render('index.html', {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "express": "4.13.3",
     "gcloud": "^0.27.0",
     "hogan-express": "0.5.2",
-    "cookie-parser": "1.4.1"
+    "cookie-parser": "1.4.1",
+    "uuid": "2.0.1"
   },
   "devDependencies": {
     "jshint": "^2.8.0"

--- a/views/amp-access/article.html
+++ b/views/amp-access/article.html
@@ -45,6 +45,9 @@
           "vars": {
             "account": "UA-72665224-1"
           },
+          "requests": {
+            "host": "<% host %>"     
+          },
           "triggers": {
             "default pageview": {
               "on": "visible",


### PR DESCRIPTION
The sample shows how to use a the publisher
server to use the same clientId on analytics
for the publisher website and AMP pages