### PR TITLE
add license headers to all JS files

### DIFF
--- a/amp-paywall-demo/controllers/amp-access/api.js
+++ b/amp-paywall-demo/controllers/amp-access/api.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var express = require('express');
 var router = express.Router();
-var privateKey = 
+var privateKey =
 `-----BEGIN RSA PRIVATE KEY-----
 MIICWgIBAAKBgGuSzXXydlcWrOpzmTyx/e1D/vNGZcfcgXrGq2eM6eX8YbA9OX+w
 3+hHfUN88l4O5w+aQabc+/Edz90KOdqeIbAnGMCwnieIJj5Fdkvk+MtRRVzu5aVh
@@ -38,11 +39,11 @@ var PaywallAccess = require('../../models/amp-access');
 var User = require('../../models/user');
 var jwt = require('jsonwebtoken');
 
-/** 
- # Authorization is configured via authorization property in the AMP Access 
- # Configuration section. It is a credentialed CORS endpoint. 
- # 
- # This endpoint produces the authorization response that can be used in the 
+/**
+ # Authorization is configured via authorization property in the AMP Access
+ # Configuration section. It is a credentialed CORS endpoint.
+ #
+ # This endpoint produces the authorization response that can be used in the
  # content markup expressions to show/hide different parts of content.
  */
 router.get('/amp-authorization.json', function(req, res) {
@@ -84,7 +85,7 @@ router.get('/amp-authorization.json', function(req, res) {
   } else {
     // metered access
     var hasAccess = paywallAccess.hasAccess(referrer, viewedUrl);
-    // send an increased view count if user hasn't already seen the url 
+    // send an increased view count if user hasn't already seen the url
     // the actual view is counted in the pingback
     var views = paywallAccess.numViews;
     if (hasAccess && !paywallAccess.hasAlreadyVisisted()) {
@@ -103,7 +104,7 @@ router.get('/amp-authorization.json', function(req, res) {
     var jwtResponse = {
       'aud': 'ampproject.org',
       'iss': req.get('host'),
-      'exp': new Date().getTime() + FIVE_MINUTES, 
+      'exp': new Date().getTime() + FIVE_MINUTES,
       'amp_authdata': response
     };
     var encodedResponse = jwt.sign(jwtResponse, privateKey, { algorithm: 'RS256'});
@@ -115,8 +116,8 @@ router.get('/amp-authorization.json', function(req, res) {
   }
 });
 
-/** 
- * Pingback is configured via pingback property in the AMP Access Configuration section. 
+/**
+ * Pingback is configured via pingback property in the AMP Access Configuration section.
  * It must be a credentialed CORS endpoint. Pingback must not produce a response.
  *
  * Use the pingback to:
@@ -143,11 +144,11 @@ router.post('/amp-pingback', function(req, res) {
 
 /**
  * Retrieves a logged in user via cookie. If it exists it will store the
- * user with the Reader ID. This makes it possible to automatically 
- * login paywall users if they are already logged into your site. 
+ * user with the Reader ID. This makes it possible to automatically
+ * login paywall users if they are already logged into your site.
  */
 function matchUserToReaderId(req, paywallAccess) {
-  //retrieve the login cookie. 
+  //retrieve the login cookie.
   var email = req.cookies.email;
   var user = User.findByEmail(email);
   if (user) {

--- a/amp-paywall-demo/controllers/amp-access/demo.js
+++ b/amp-paywall-demo/controllers/amp-access/demo.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var express = require('express');
@@ -26,10 +27,10 @@ for (var i = 0; i < 10; i++) {
 }
 
 /**
- * Return an Article 
+ * Return an Article
  **/
 router.get('/((\\d+))', function(req, res) {
-  var id = parseInt(req.params[0]);  
+  var id = parseInt(req.params[0]);
   var host = req.get('host');
   // http works only on localhost
   var protocol = host.startsWith('localhost') ? 'http' : 'https';
@@ -39,7 +40,7 @@ router.get('/((\\d+))', function(req, res) {
 });
 
 /**
- * List all Articles 
+ * List all Articles
  **/
 router.get('/', function(req, res) {
   res.render('amp-access/washingtonpost/list', {

--- a/amp-paywall-demo/controllers/amp-access/index.js
+++ b/amp-paywall-demo/controllers/amp-access/index.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/amp-paywall-demo/controllers/amp-access/login.js
+++ b/amp-paywall-demo/controllers/amp-access/login.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var express = require('express');
@@ -23,11 +24,11 @@ var PaywallAccess = require('../../models/amp-access');
 var AUTH_COOKIE_MAX_AGE = 1000 * 60 * 60 * 2; //2 hours
 
 /**
- * The link to the Login Page is configured via the login property in the 
- * AMP Access Configuration section. 
+ * The link to the Login Page is configured via the login property in the
+ * AMP Access Configuration section.
  *
- * Login Page is simply a normal Web page with no special constraints, other 
- * than it should function well as a browser dialog. 
+ * Login Page is simply a normal Web page with no special constraints, other
+ * than it should function well as a browser dialog.
  */
 router.get('/', function(req, res) {
   console.log('Serve /login');
@@ -38,7 +39,7 @@ router.get('/', function(req, res) {
 });
 
 /**
- * A simple login flow. The important thing is to map the user 
+ * A simple login flow. The important thing is to map the user
  * to it's AMP Reader ID.
  */
 router.post('/submit', function(req, res) {
@@ -52,13 +53,13 @@ router.post('/submit', function(req, res) {
   if (!user || user.password != password) {
     console.log('Login failed: ', user);
     res.redirect('/?rid=' + readerId + "&return=" + returnUrl);
-    return;    
+    return;
   }
   console.log('Login success: ', user);
 
   // map the user to the AMP Reader ID
   var paywallAccess = PaywallAccess.getOrCreate(readerId);
-  paywallAccess.user = user;  
+  paywallAccess.user = user;
 
   // set user as logged in via cookie
   res.cookie('email', user.email, {
@@ -80,15 +81,15 @@ router.get('/reset', function(req, res) {
 });
 
 /**
- * Simple user logout. 
+ * Simple user logout.
  */
 router.get('/logout', function(req, res) {
   var email = req.cookies.email;
   if (email) {
   	PaywallAccess.deleteByEmail(email);
-  	res.clearCookie('email');	
+  	res.clearCookie('email');
   }
-  res.redirect(req.header('Referer') || '/');  
+  res.redirect(req.header('Referer') || '/');
 });
 
 module.exports = router;

--- a/amp-paywall-demo/controllers/amp-access/sample.js
+++ b/amp-paywall-demo/controllers/amp-access/sample.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var express = require('express');
@@ -26,7 +27,7 @@ for (var i = 0; i < 10; i++) {
 }
 
 /**
- * List all Articles 
+ * List all Articles
  **/
 router.get('/', function(req, res) {
   res.render('amp-access/list', {
@@ -48,7 +49,7 @@ router.get('/fcf', function(req, res) {
 });
 
 /**
- * View a single Article 
+ * View a single Article
  **/
 router.get(['/((\\d+))', '/server/((\\d+))'], function(req, res) {
   var id = parseInt(req.params[0]);
@@ -70,7 +71,7 @@ router.get(['/((\\d+))', '/server/((\\d+))'], function(req, res) {
 });
 
 router.get('/washingtonpost/((\\d+))', function(req, res) {
-  var id = parseInt(req.params[0]);  
+  var id = parseInt(req.params[0]);
   var host = req.get('host');
   // http works only on localhost
   var protocol = host.startsWith('localhost') ? 'http' : 'https';

--- a/amp-paywall-demo/controllers/amp-analytics/demo.js
+++ b/amp-paywall-demo/controllers/amp-analytics/demo.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/amp-paywall-demo/controllers/amp-analytics/embed.js
+++ b/amp-paywall-demo/controllers/amp-analytics/embed.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/amp-paywall-demo/controllers/amp-analytics/index.js
+++ b/amp-paywall-demo/controllers/amp-analytics/index.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/amp-paywall-demo/controllers/amp-analytics/ping.js
+++ b/amp-paywall-demo/controllers/amp-analytics/ping.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ var router = express.Router();
 var Analytics = require('../../models/amp-analytics');
 
 /**
- * Registers an event for the given account. 
+ * Registers an event for the given account.
  *
  * Example: /amp-analytics/ping?acccount=AN_ACCOUNT&event=AN_EVENT
  */

--- a/amp-paywall-demo/controllers/amp-analytics/proxy.js
+++ b/amp-paywall-demo/controllers/amp-analytics/proxy.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,13 @@ var GA_HOST = "https://www.google-analytics.com";
 var EXPIRES = 60 * 60 * 24 * 365; //1 year
 
 /**
- * Adds the uid parameter to the google-analytics request 
- * and redirects to google-analytics. 
- * 
+ * Adds the uid parameter to the google-analytics request
+ * and redirects to google-analytics.
+ *
  * More info on UserID for google-analytics here:
  *   - https://support.google.com/analytics/answer/3123662
  *   - https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#uid
- *   
+ *
  * Example: /collect?cid=1234
  */
 router.post('/', function(req, res) {
@@ -43,12 +43,12 @@ router.post('/', function(req, res) {
   if (!uid) {
     // Create a new userId if one doesn't exist.
     uid = uuid.v4();
-    console.log("Generated new userId: " + uid);  
+    console.log("Generated new userId: " + uid);
 
     // The desktop website should be modified to use the value of the
     // userId cookie as the userId in GA.
-    res.cookie('userId', uid, { maxAge: EXPIRES, httpOnly: true });    
-  }  
+    res.cookie('userId', uid, { maxAge: EXPIRES, httpOnly: true });
+  }
 
   console.log("Redirecting to Google Analytics with UID: " + uid);
 

--- a/amp-paywall-demo/controllers/amp-user-notification/index.js
+++ b/amp-paywall-demo/controllers/amp-user-notification/index.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/amp-paywall-demo/controllers/index.js
+++ b/amp-paywall-demo/controllers/index.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/amp-paywall-demo/middlewares/amp-access-cors.js
+++ b/amp-paywall-demo/middlewares/amp-access-cors.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var url = require('url');
@@ -22,11 +23,11 @@ var VALID_SOURCE_ORIGINS = [/ampbyexample\.com/g, /amp-by-example-staging\.appsp
     /rocky-sierra-1919\.herokuapp\.com/g, /limitless-tundra-65881\.herokuapp\.com/g];
 
 /**
- * Enable CORS for all AMP API requests. More information here: 
- * https://github.com/ampproject/amphtml/blob/master/spec/amp-cors-requests.md 
+ * Enable CORS for all AMP API requests. More information here:
+ * https://github.com/ampproject/amphtml/blob/master/spec/amp-cors-requests.md
  */
 module.exports = function(req, res, next) {
-  // Enable CORS only for API requests 
+  // Enable CORS only for API requests
   if (req.url.indexOf('/api/') > -1) {
     // Verify the origin (AMP and publisher domain)
     var requestingOrigin = req.headers.origin;
@@ -45,20 +46,20 @@ module.exports = function(req, res, next) {
       return;
     }
     console.log('---- valid requesting origins');
-    // Return the allowed requesting origin 
+    // Return the allowed requesting origin
     res.header('Access-Control-Allow-Origin', requestingOrigin);
     // Allow CORS credentials
     res.header('Access-Control-Allow-Credentials', 'true');
     // Allow the CORS response to contain the "AMP-Access-Control-Allow-Source-Origin" header.
     res.setHeader('Access-Control-Expose-Headers', 'AMP-Access-Control-Allow-Source-Origin');
-    // The source origin that is allowed to read the authorization response 
+    // The source origin that is allowed to read the authorization response
     res.setHeader('AMP-Access-Control-Allow-Source-Origin', requestingSourceOrigin);
   }
   next();
 };
 
 /**
- * Check requesting origin. This has to be restricted to only allow 
+ * Check requesting origin. This has to be restricted to only allow
  * the following origins:
  *
  * - *.ampproject.org
@@ -88,7 +89,7 @@ function isValidSourceOrigin(req, sourceOrigin) {
 }
 
 /**
- * Returns true if any of the validOrigins patterns matches the given 
+ * Returns true if any of the validOrigins patterns matches the given
  * origin.
  */
 function matchesAnyOrigin(validOrigins, origin) {

--- a/amp-paywall-demo/middlewares/logging.js
+++ b/amp-paywall-demo/middlewares/logging.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 /* Log all incoming requests */

--- a/amp-paywall-demo/models/amp-access.js
+++ b/amp-paywall-demo/models/amp-access.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var url = require('url');
@@ -25,7 +26,7 @@ var FIRST_CLICK_FREE_TEST_PATH = 'fcf';
 
 /**
  * A simple paywall implementation. It understands AMP Reader Ids
- * and users. Supported features are: 
+ * and users. Supported features are:
  *
  * - Metered paywall
  * - First-click-free
@@ -45,15 +46,15 @@ class PaywallAccess {
    * Returns true if the user is a subscriber.
    */
   isSubscriber() {
-    if (!this.user) { 
+    if (!this.user) {
       return false;
     }
     return this.user.subscriber;
   }
 
   /**
-   * Determines based on the request referrer whether 
-   * First-Click-Free is supported. 
+   * Determines based on the request referrer whether
+   * First-Click-Free is supported.
    */
   isFirstClickFree(referrer) {
     var host = url.parse(referrer);
@@ -62,12 +63,12 @@ class PaywallAccess {
       referrer.indexOf(FIRST_CLICK_FREE_TEST_PATH) == -1) {
         return false;
     }
-    return !this.viewedUrlsByReferrer[host] || 
+    return !this.viewedUrlsByReferrer[host] ||
       this.viewedUrlsByReferrer[host] < MAX_FIRST_CLICK_FREE_VIEWS;
   }
 
   /**
-   * Registers a viewed article. Counts views per referrer. 
+   * Registers a viewed article. Counts views per referrer.
    */
   registerView(referrer, viewedUrl) {
     if (!this.hasAccess(referrer, viewedUrl)) {
@@ -79,7 +80,7 @@ class PaywallAccess {
       if (this.viewedUrlsByReferrer[host]) {
         this.viewedUrlsByReferrer[host]++;
       } else {
-        this.viewedUrlsByReferrer[host] = 1;      
+        this.viewedUrlsByReferrer[host] = 1;
       }
     } else if (!this.user && !this.viewedUrls[viewedUrl]) {
       this.numViews++;
@@ -91,9 +92,9 @@ class PaywallAccess {
    * Returns true if the user has access to the given URL.
    */
   hasAccess(referrer, url) {
-    return this.isSubscriber() || 
-      this.hasAlreadyVisisted(url) || 
-      this.isFirstClickFree(referrer) || 
+    return this.isSubscriber() ||
+      this.hasAlreadyVisisted(url) ||
+      this.isFirstClickFree(referrer) ||
       this.numViews < MAX_VIEWS;
   }
 
@@ -145,7 +146,7 @@ exports.deleteByEmail = function(email) {
   for (var readerId in READER_ID_TO_MAPPING) {
     var user = READER_ID_TO_MAPPING[readerId].user;
     if (user && user.email == email) {
-      this.deleteByReaderId(readerId); 
+      this.deleteByReaderId(readerId);
     }
   }
 };

--- a/amp-paywall-demo/models/amp-analytics.js
+++ b/amp-paywall-demo/models/amp-analytics.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var EVENTS = {};

--- a/amp-paywall-demo/models/user-notifications.js
+++ b/amp-paywall-demo/models/user-notifications.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var DISMISSED_NOTIFICATIONS = {};

--- a/amp-paywall-demo/models/user.js
+++ b/amp-paywall-demo/models/user.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 "use strict";
 
 var USERS = {};

--- a/amp-pwa/server.js
+++ b/amp-pwa/server.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // This file contains an Express server that does two things:
 //
 // 1. During development, provide data APIs for the web app to consume

--- a/amp-pwa/src/components/article.js
+++ b/amp-pwa/src/components/article.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Link } from 'react-router';
 import React from 'react';
 import './article.css'

--- a/amp-pwa/src/components/article.test.js
+++ b/amp-pwa/src/components/article.test.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Article from './article';

--- a/amp-pwa/src/components/home.js
+++ b/amp-pwa/src/components/home.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import Article from './article';
 import './home.css';

--- a/amp-pwa/src/components/home.test.js
+++ b/amp-pwa/src/components/home.test.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Home from './home';

--- a/amp-pwa/src/components/shell.js
+++ b/amp-pwa/src/components/shell.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Grid, Navbar } from 'react-bootstrap';
 import { Link } from 'react-router';

--- a/amp-pwa/src/components/shell.test.js
+++ b/amp-pwa/src/components/shell.test.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Shell from './shell';

--- a/amp-pwa/src/index.js
+++ b/amp-pwa/src/index.js
@@ -1,3 +1,19 @@
+/** @license
+ * Copyright 2015 - present The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import AMPDocument from './components/amp-document/amp-document';
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
The `amp-pwa` JS files were missing the license header, which the OSPO requires on all source files for Google-sponsored OSS projects.  I've added them here.