### PR TITLE
Fix positioning of 'click-preventer' <div>

### DIFF
--- a/amp-pwa-reader/src/js/DragObserver.js
+++ b/amp-pwa-reader/src/js/DragObserver.js
@@ -21,6 +21,8 @@ class DragObserver extends Evented {
     div.style.width = '30px';
     div.style.height = '30px';
     div.style.position = 'absolute';
+    div.style.left = '0';
+    div.style.top = '0';
     div.style.zIndex = '1000';
     return div;
   }
@@ -63,9 +65,15 @@ class DragObserver extends Evented {
     this.eventMovePrev = this.eventMove || this.eventStart;
     this.eventMove = event;
 
-    var position = {
-      x: (this.axis === 'both' || this.axis === 'x') ? -(this.eventDown.pageX - this.eventMove.pageX) : 0,
-      y: (this.axis === 'both' || this.axis === 'y') ? -(this.eventDown.pageY - this.eventMove.pageY) : 0
+    // keep track of position before axis 'removal'
+    let rawPosition = {
+      x: -(this.eventDown.pageX - this.eventMove.pageX),
+      y: -(this.eventDown.pageY - this.eventMove.pageY)
+    }
+
+    let position = {
+      x: (this.axis === 'both' || this.axis === 'x') ? rawPosition.x : 0,
+      y: (this.axis === 'both' || this.axis === 'y') ? rawPosition.y : 0
     };
 
     // only execute start callback when moved at least one pixel (configured as 'distance')
@@ -77,8 +85,10 @@ class DragObserver extends Evented {
 
     // only execute move callback when properly started
     if(this._started) {
-      this._clickPreventer.style.transform = 'translate3d(' + (this.eventDown.pageX + position.x - 15) + 'px, ' + (this.eventDown.pageY + position.y - 15) + 'px, 0)';
+      this._clickPreventer.style.transform = 'translate3d(' + (this.eventDown.pageX + rawPosition.x - 15) + 'px, ' + (this.eventDown.pageY + rawPosition.y - 15) + 'px, 0)';
       this.trigger('move', position);
+
+
     }
 
   }

--- a/amp-pwa-reader/src/js/DragObserver.js
+++ b/amp-pwa-reader/src/js/DragObserver.js
@@ -87,10 +87,7 @@ class DragObserver extends Evented {
     if(this._started) {
       this._clickPreventer.style.transform = 'translate3d(' + (this.eventDown.pageX + rawPosition.x - 15) + 'px, ' + (this.eventDown.pageY + rawPosition.y - 15) + 'px, 0)';
       this.trigger('move', position);
-
-
     }
-
   }
 
   _stop (event) {


### PR DESCRIPTION
The app uses an invisible `<div>` to prevent a click event to take place when the sidebar menu is opened with a drag gesture. This PR fixes the positioning of that div to track the movement of the dragging gesture.  