### PR TITLE
Replace gulp-util with gulp-noop; pin workbox-build to version 2.1.3

### DIFF
--- a/amp-pwa-reader/gulpfile.js
+++ b/amp-pwa-reader/gulpfile.js
@@ -5,7 +5,7 @@ let uglifyes = require('uglify-es');
 let composer = require('gulp-uglify/composer');
 const uglify = composer(uglifyes, console);
 const gulp = require('gulp');
-const gutil = require('gulp-util');
+const noop = require('gulp-noop');
 const replace = require('gulp-replace');
 const plumber = require('gulp-plumber');
 const autoprefixer = require('gulp-autoprefixer');
@@ -71,7 +71,7 @@ function scripts() {
       mangle: {
         safari10: true
       }
-    }) : gutil.noop())
+    }) : noop())
     .pipe(gulp.dest(paths.scripts.dest));
 }
 
@@ -83,10 +83,10 @@ function inline() {
   return gulp.src('src/index.html')
     .pipe(css ?
       replace('/* REPLACED-INLINE-STYLESHEET */', fs.readFileSync('./dist/main.css', 'utf8')) :
-      gutil.noop())
+      noop())
     .pipe(scripts ?
       replace('/* REPLACED-INLINE-JAVASCRIPT */', fs.readFileSync('./.tmp/scripts.js', 'utf8')) :
-      gutil.noop())
+      noop())
     .pipe(gulp.dest('dist/'));
 }
 

--- a/amp-pwa-reader/package.json
+++ b/amp-pwa-reader/package.json
@@ -15,13 +15,14 @@
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-autoprefixer": "*",
     "gulp-concat": "*",
+    "gulp-noop": "*",
     "gulp-plumber": "*",
     "gulp-replace": "*",
     "gulp-sass": "*",
     "gulp-sourcemaps": "*",
     "gulp-uglify": "*",
     "uglify-es": "*",
-    "workbox-build": "*",
+    "workbox-build": "2.1.3",
     "workbox-sw": "*"
   }
 }


### PR DESCRIPTION
* Gulp 4.0.0 has deprecated gulp-util. Since we only use it for gutil.noop(), replace it with the lightweight module gulp-noop that serves this exact same purpose.
* workbox-build@3.0.0#injectManifest expect the Service Worker to have a method called precacheAndRoute, but our Service Worker has a method called precache, which workbox-build@2.1.3@injectManifest expects. Basically, pin the version of workbox-build to the last one that worked, until someone else feels like rolling a forward fix :)