### PR TITLE
Remove gulp-util from dependencies

### DIFF
--- a/amp-pwa-reader/package.json
+++ b/amp-pwa-reader/package.json
@@ -25,7 +25,6 @@
     "gulp-sass": "*",
     "gulp-sourcemaps": "*",
     "gulp-uglify": "*",
-    "gulp-util": "^3.0.8",
     "memory-cache": "^0.2.0",
     "request": "^2.81.0",
     "uglify-es": "*",


### PR DESCRIPTION
Remove gulp-util from dependencies, as @danielrozenberg removed it from gulpfile anyway. (It's deprecated in Gulp 4.0.0.)