### PR TITLE
Fix 'mustache.to_html is not a function' in amp-camp demo

### DIFF
--- a/amp-camp/src/server/server.js
+++ b/amp-camp/src/server/server.js
@@ -75,7 +75,7 @@ app.engine('html', function(filePath, options, callback) {
         if (err)
             return callback(err);        
 
-        let rendered = mustache.to_html(content.toString(), options);
+        let rendered = mustache.render(content.toString(), options);
         return callback(null, rendered);
     });
 });


### PR DESCRIPTION
This commit solves the following error while running Gulp:

```
let rendered = mustache.to_html(content.toString(), options);
                                ^
TypeError: mustache.to_html is not a function
```